### PR TITLE
remove .dockerignore.Zone.Identifier

### DIFF
--- a/api/.dockerignore:Zone.Identifier
+++ b/api/.dockerignore:Zone.Identifier
@@ -1,4 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-ReferrerUrl=https://github.com/api-platform/api-platform/releases
-HostUrl=https://codeload.github.com/api-platform/api-platform/zip/refs/tags/v3.0.0-rc.1

--- a/pwa/.dockerignore:Zone.Identifier
+++ b/pwa/.dockerignore:Zone.Identifier
@@ -1,4 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-ReferrerUrl=https://github.com/api-platform/api-platform/releases
-HostUrl=https://codeload.github.com/api-platform/api-platform/zip/refs/tags/v3.0.0-rc.1


### PR DESCRIPTION
This PR aims to remove .dockerignore:Zone.Identifier